### PR TITLE
항상 true가 나오는 경우를 위한 try catch로 변경

### DIFF
--- a/custom_components/smartthings/climate.py
+++ b/custom_components/smartthings/climate.py
@@ -22,14 +22,13 @@ from homeassistant.components.climate import (
     SWING_HORIZONTAL,
 )
 
-import sys
-
-if 'custom_components.climate' not in sys.modules:
-    from homeassistant.components.climate import ClimateEntity
-    from homeassistant.components.climate.const import HVACMode
-else:
+try:
     from custom_components.climate import ClimateEntity
     from custom_components.climate.const import HVACMode
+except ImportError:
+    from homeassistant.components.climate import ClimateEntity
+    from homeassistant.components.climate.const import HVACMode
+
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature


### PR DESCRIPTION
if 'custom_components.climate' not in sys.modules 이부분이 항상 true가 되어서 커스텀 컴포넌트를 import 못하는 이슈를 발견하였습니다. try catch로 바꾸는건 어떨까요?